### PR TITLE
docs: update README with governance module support notice for v0.3.1

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,9 @@ The Javascript & TypeScript SDK for FirmaChain
 
 Firma-js is a SDK for writing applications based on javascript & typescript. You can use it client web app or Node.js. This SDK is created inspired by cosmjs and several sdk. All functions of the FirmaChain can be accessed at the service level.
 
+⚠️ Currently, the governance module is not available as it has not yet been patched.
+A patch is planned soon to enable the governance module in version 0.3.1.
+
 ## Features
  Most cosmos sdk features are supported
 - Wallet / Bank

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ The Javascript & TypeScript SDK for FirmaChain
 
 Firma-js is a SDK for writing applications based on javascript & typescript. You can use it client web app or Node.js. This SDK is created inspired by cosmjs and several sdk. All functions of the FirmaChain can be accessed at the service level.
 
-⚠️ Currently, the governance module is not available as it has not yet been patched.
+⚠️ We wanted to let you know that the governance module is not accessible at the moment. It requires a patch to become fully operational, which we're actively preparing. We plan to release this patch soon as part of version 0.3.1, at which point the governance module will be enabled. 
 A patch is planned soon to enable the governance module in version 0.3.1.
 
 ## Features


### PR DESCRIPTION
### Summary

This PR adds a notice to the `README.md` regarding the current status of the `governance` module.

### Details

- Informs users that the `governance` module is currently unavailable due to an unpatched implementation.
- Mentions that a patch is planned for version `0.3.1` to enable its usage.

### Motivation

To provide clarity for users attempting to use the governance-related APIs and prevent confusion during development or integration.

### Related

No related issues.

### Checklist

- [x] Documentation updated
- [ ] Governance patch implemented (planned for `v0.3.1`)