### PR TITLE
chore: bump version to 0.3.0-beta1 for pre-release

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@firmachain/firma-js",
-  "version": "0.3.0",
+  "version": "0.3.0-beta1",
   "description": "The Official FirmaChain Javascript SDK written in Typescript",
   "main": "dist/index.js",
   "typings": "dist/index.d.ts",


### PR DESCRIPTION
# Pre-release: v0.3.0-beta1

This PR updates only the version field in package.json to v0.3.0-beta1,
as the previous v0.3.0 version was previously unpublished and cannot be re-published due to npm policy.

# Changes

Bumped package.json version to 0.3.0-beta1

# Context

- The original 0.3.0 version was unpublished and cannot be reused.
- To proceed with publishing under a new version, we’re releasing a pre-release version.
- This version is intended for beta testing before an official stable release (0.3.0 or 0.3.1).

# Release Plan
- To be published via npm publish --tag beta
- Will not be published under the latest tag
- Once stable, it will be promoted to a formal release version

# Review Notes
- No changes except for version bump
- Confirm whether a changelog or release note is needed prior to publish