### PR TITLE
feat: validation using fromPartial and add getParamAs***Params to provide appropriate typed object

### DIFF
--- a/sdk/FirmaGovService.ts
+++ b/sdk/FirmaGovService.ts
@@ -721,15 +721,15 @@ export class FirmaGovService {
             // return as GovParams type
             return {
                 minDeposit: result.min_deposit,
-                maxDepositPeriod: result.max_deposit_period,
-                votingPeriod: result.voting_period,
+                maxDepositPeriod: FirmaUtil.createDurationFromString(result.max_deposit_period),
+                votingPeriod: FirmaUtil.createDurationFromString(result.voting_period),
                 quorum: result.quorum,
                 threshold: result.threshold,
                 vetoThreshold: result.veto_threshold,
                 minInitialDepositRatio: result.min_initial_deposit_ratio,
                 proposalCancelRatio: result.proposal_cancel_ratio,
                 proposalCancelDest: result.proposal_cancel_dest,
-                expeditedVotingPeriod: result.expedited_voting_period,
+                expeditedVotingPeriod: FirmaUtil.createDurationFromString(result.expedited_voting_period),
                 expeditedThreshold: result.expedited_threshold,
                 expeditedMinDeposit: result.expedited_min_deposit,
                 burnVoteQuorum: result.burn_vote_quorum,

--- a/sdk/FirmaGovService.ts
+++ b/sdk/FirmaGovService.ts
@@ -28,6 +28,7 @@ import {
 import { MsgSoftwareUpgrade } from "@kintsugi-tech/cosmjs-types/cosmos/upgrade/v1beta1/tx";
 import { MsgCommunityPoolSpend } from "@kintsugi-tech/cosmjs-types/cosmos/distribution/v1beta1/tx";
 import { Proposal, Params as GovParams } from "@kintsugi-tech/cosmjs-types/cosmos/gov/v1/gov";
+import { Params as StakingParams } from "@kintsugi-tech/cosmjs-types/cosmos/staking/v1beta1/staking";
 // import { Params as GovParams } from "cosmjs-types/cosmos/gov/v1/gov";
 
 export class FirmaGovService {
@@ -98,24 +99,30 @@ export class FirmaGovService {
         title: string,
         summary: string,
         initialDepositFCT: number,
-        params: StakingParamType,
+        params: StakingParams,
         metadata: string = "",
         txMisc: TxMisc = DefaultTxMisc): Promise<number> {
         
         try {
+            // Add validation logic here using fromPartial
+            const requestedParams = {
+                authority: FirmaGovService.GOV_AUTHORITY,
+                params: params
+            }
+            const fromPartialParams = StakingMsgUpdateParams.fromPartial({
+                authority: FirmaGovService.GOV_AUTHORITY,
+                params: params
+            });
+            const paramsEncoded = StakingMsgUpdateParams.encode(requestedParams).finish();
+            const fromPartialEncoded = StakingMsgUpdateParams.encode(fromPartialParams).finish();
+
+            if (Buffer.from(paramsEncoded).toString('hex') !== Buffer.from(fromPartialEncoded).toString('hex')) {
+                throw new Error("All staking parameters must be provided. Use Staking.getParamsAsStakingParams() to get current values and override only the parameters you want to change.");
+            }
+
             const message = {
                 typeUrl: "/cosmos.staking.v1beta1.MsgUpdateParams",
-                value: StakingMsgUpdateParams.encode(StakingMsgUpdateParams.fromPartial({
-                    authority: FirmaGovService.GOV_AUTHORITY,
-                    params: {
-                        bondDenom: params.bond_denom,
-                        maxEntries: params.max_entries,
-                        maxValidators: params.max_validators,
-                        minCommissionRate: params.min_commission_rate,
-                        historicalEntries: params.historical_entries,
-                        unbondingTime: params.unbonding_time,
-                    }
-                })).finish()
+                value: paramsEncoded
             };
             const txRaw = await this.getSignedTxSubmitStakingParamsUpdateProposal(wallet, title, summary, initialDepositFCT, [message], metadata, txMisc);
             return await FirmaUtil.estimateGas(txRaw);
@@ -146,7 +153,7 @@ export class FirmaGovService {
             const fromPartialEncoded = GovMsgUpdateParmas.encode(fromPartialParams).finish();
 
             if (Buffer.from(paramsEncoded).toString('hex') !== Buffer.from(fromPartialEncoded).toString('hex')) {
-                throw new Error("All governance parameters must be provided. Use getParam() to get current values and override only the parameters you want to change.");
+                throw new Error("All governance parameters must be provided. Use getParamAsGovParams() to get current values and override only the parameters you want to change.");
             }
             
             const message = {
@@ -697,6 +704,37 @@ export class FirmaGovService {
             const result = await queryClient.queryGetParam();
 
             return result;
+
+        } catch (error) {
+            FirmaUtil.printLog(error);
+            throw error;
+        }
+    }
+
+    async getParamAsGovParams(): Promise<GovParams> {
+        try {
+            const queryClient = new GovQueryClient(this.config.restApiAddress);
+            const result = await queryClient.queryGetParam(); // get result as GovParamType
+
+            // return as GovParams type
+            return {
+                minDeposit: result.min_deposit,
+                maxDepositPeriod: FirmaUtil.parseDurationString(result.max_deposit_period),
+                votingPeriod: FirmaUtil.parseDurationString(result.voting_period),
+                quorum: result.quorum,
+                threshold: result.threshold,
+                vetoThreshold: result.veto_threshold,
+                minInitialDepositRatio: result.min_initial_deposit_ratio,
+                proposalCancelRatio: result.proposal_cancel_ratio,
+                proposalCancelDest: result.proposal_cancel_dest,
+                expeditedVotingPeriod: FirmaUtil.parseDurationString(result.expedited_voting_period),
+                expeditedThreshold: result.expedited_threshold,
+                expeditedMinDeposit: result.expedited_min_deposit,
+                burnVoteQuorum: result.burn_vote_quorum,
+                burnProposalDepositPrevote: result.burn_proposal_deposit_prevote,
+                burnVoteVeto: result.burn_vote_veto,
+                minDepositRatio: result.min_deposit_ratio
+            };
 
         } catch (error) {
             FirmaUtil.printLog(error);

--- a/sdk/FirmaGovService.ts
+++ b/sdk/FirmaGovService.ts
@@ -721,15 +721,15 @@ export class FirmaGovService {
             // return as GovParams type
             return {
                 minDeposit: result.min_deposit,
-                maxDepositPeriod: FirmaUtil.parseDurationString(result.max_deposit_period),  // Todo: fix this function
-                votingPeriod: FirmaUtil.parseDurationString(result.voting_period),
+                maxDepositPeriod: result.max_deposit_period,
+                votingPeriod: result.voting_period,
                 quorum: result.quorum,
                 threshold: result.threshold,
                 vetoThreshold: result.veto_threshold,
                 minInitialDepositRatio: result.min_initial_deposit_ratio,
                 proposalCancelRatio: result.proposal_cancel_ratio,
                 proposalCancelDest: result.proposal_cancel_dest,
-                expeditedVotingPeriod: FirmaUtil.parseDurationString(result.expedited_voting_period),
+                expeditedVotingPeriod: result.expedited_voting_period,
                 expeditedThreshold: result.expedited_threshold,
                 expeditedMinDeposit: result.expedited_min_deposit,
                 burnVoteQuorum: result.burn_vote_quorum,

--- a/sdk/FirmaStakingService.ts
+++ b/sdk/FirmaStakingService.ts
@@ -410,12 +410,12 @@ export class FirmaStakingService {
             const result = await queryClient.queryGetParams();
 
             return {
-                unbondingTime: result.unbonding_time,
+                unbondingTime: FirmaUtil.createDurationFromString(result.unbonding_time),
                 maxValidators: result.max_validators,
                 maxEntries: result.max_entries,
                 historicalEntries: result.historical_entries,
                 bondDenom: result.bond_denom,
-                minCommissionRate: result.min_commission_rate
+                minCommissionRate: FirmaUtil.processCommissionRate(result.min_commission_rate)
             };
 
         } catch (error) {

--- a/sdk/FirmaStakingService.ts
+++ b/sdk/FirmaStakingService.ts
@@ -18,6 +18,7 @@ import { DefaultTxMisc, FirmaUtil, getSignAndBroadcastOption } from "./FirmaUtil
 import { DeliverTxResponse } from "./firmachain/common/stargateclient";
 import { Description } from "cosmjs-types/cosmos/staking/v1beta1/staking";
 import { MsgCreateValidator } from "cosmjs-types/cosmos/staking/v1beta1/tx";
+import { Params as StakingParams } from "@kintsugi-tech/cosmjs-types/cosmos/staking/v1beta1/staking";
 
 export enum StakingValidatorStatus {
     ALL = "",
@@ -396,6 +397,26 @@ export class FirmaStakingService {
             const result = await queryClient.queryGetParams();
 
             return result;
+
+        } catch (error) {
+            FirmaUtil.printLog(error);
+            throw error;
+        }
+    }
+
+    async getParamsAsStakingParams(): Promise<StakingParams> {
+        try {
+            const queryClient = new StakingQueryClient(this.config.restApiAddress);
+            const result = await queryClient.queryGetParams();
+
+            return {
+                unbondingTime: FirmaUtil.parseDurationString(result.unbonding_time), // todo: fix this function
+                maxValidators: result.max_validators,
+                maxEntries: result.max_entries,
+                historicalEntries: result.historical_entries,
+                bondDenom: result.bond_denom,
+                minCommissionRate: FirmaUtil.processCommissionRate(result.min_commission_rate)
+            };
 
         } catch (error) {
             FirmaUtil.printLog(error);

--- a/sdk/FirmaStakingService.ts
+++ b/sdk/FirmaStakingService.ts
@@ -410,12 +410,12 @@ export class FirmaStakingService {
             const result = await queryClient.queryGetParams();
 
             return {
-                unbondingTime: FirmaUtil.parseDurationString(result.unbonding_time), // todo: fix this function
+                unbondingTime: result.unbonding_time,
                 maxValidators: result.max_validators,
                 maxEntries: result.max_entries,
                 historicalEntries: result.historical_entries,
                 bondDenom: result.bond_denom,
-                minCommissionRate: FirmaUtil.processCommissionRate(result.min_commission_rate)
+                minCommissionRate: result.min_commission_rate
             };
 
         } catch (error) {

--- a/sdk/FirmaUtil.ts
+++ b/sdk/FirmaUtil.ts
@@ -579,23 +579,6 @@ export class FirmaUtil {
             throw new Error(`Invalid commission rate format: ${commissionRate}`);
         }
     }
-
-    /**
-     * Safely processes all staking params to prevent protobuf conversion errors.
-     * 
-     * @param params - Raw staking params from query
-     * @returns Processed staking params safe for protobuf usage
-     */
-    static processStakingParams(params: any): any {
-        return {
-            unbondingTime: params.unbonding_time ? FirmaUtil.createDurationFromString(params.unbonding_time) : undefined,
-            maxValidators: params.max_validators || 0,
-            maxEntries: params.max_entries || 0,
-            historicalEntries: params.historical_entries || 0,
-            bondDenom: params.bond_denom || "",
-            minCommissionRate: FirmaUtil.processCommissionRate(params.min_commission_rate || "")
-        };
-    }
 }
 
 export const DefaultTxMisc = { memo: "", fee: 0, gas: 0, feeGranter: "" };

--- a/sdk/firmachain/gov/GovQueryClient.ts
+++ b/sdk/firmachain/gov/GovQueryClient.ts
@@ -1,7 +1,6 @@
 import Axios, { AxiosInstance } from "axios";
-import { Params, Proposal } from "@kintsugi-tech/cosmjs-types/cosmos/gov/v1/gov";
+import { Proposal } from "@kintsugi-tech/cosmjs-types/cosmos/gov/v1/gov";
 import { Coin } from "cosmjs-types/cosmos/base/v1beta1/coin";
-import { FirmaUtil } from "../../FirmaUtil";
 
 export enum ProposalStatus {
     PROPOSAL_STATUS_UNSPECIFIED = 0,
@@ -14,15 +13,15 @@ export enum ProposalStatus {
 
 export interface GovParamType {
     min_deposit: Coin[];
-    max_deposit_period: { seconds: bigint, nanos: number };
-    voting_period: { seconds: bigint, nanos: number };
+    max_deposit_period: string;
+    voting_period: string;
     quorum: string;
     threshold: string;
     veto_threshold: string;
     min_initial_deposit_ratio: string;
     proposal_cancel_ratio: string;
     proposal_cancel_dest: string;
-    expedited_voting_period: { seconds: bigint, nanos: number };
+    expedited_voting_period: string;
     expedited_threshold: string;
     expedited_min_deposit: Coin[];
     burn_vote_quorum: boolean;
@@ -62,10 +61,6 @@ export class GovQueryClient {
 
         let path = "/cosmos/gov/v1/params/deposit";
         const result = await this.axios.get(path);
-
-        result.data.params.max_deposit_period = FirmaUtil.createDurationFromString(result.data.params.max_deposit_period);
-        result.data.params.voting_period = FirmaUtil.createDurationFromString(result.data.params.voting_period);
-        result.data.params.expedited_voting_period = FirmaUtil.createDurationFromString(result.data.params.expedited_voting_period);
 
         return result.data.params;
     }

--- a/sdk/firmachain/gov/GovQueryClient.ts
+++ b/sdk/firmachain/gov/GovQueryClient.ts
@@ -14,7 +14,7 @@ export enum ProposalStatus {
 
 export interface GovParamType {
     min_deposit: Coin[];
-    max_deposit_period: { seconds: bigint | undefined, nanos: number };
+    max_deposit_period: { seconds: bigint, nanos: number };
     voting_period: { seconds: bigint, nanos: number };
     quorum: string;
     threshold: string;

--- a/sdk/firmachain/staking/StakingQueryClient.ts
+++ b/sdk/firmachain/staking/StakingQueryClient.ts
@@ -1,9 +1,8 @@
 import Axios, { AxiosInstance } from "axios";
 import { Pagination } from "../common";
-import { FirmaUtil } from "../../FirmaUtil";
 
 export interface StakingParamType {
-    unbonding_time: { seconds: bigint, nanos: number };
+    unbonding_time: string;
     max_validators: number;
     max_entries: number;
     historical_entries: number;
@@ -182,9 +181,6 @@ export class StakingQueryClient {
 
         const path = "/cosmos/staking/v1beta1/params";
         const result = await this.axios.get(path);
-        
-        result.data.params.unbonding_time = FirmaUtil.createDurationFromString(result.data.params.unbonding_time);
-        result.data.params.min_commission_rate = FirmaUtil.processCommissionRate(result.data.params.min_commission_rate);
 
         return result.data.params;
     }

--- a/test/08.gas_estimate.test.ts
+++ b/test/08.gas_estimate.test.ts
@@ -271,7 +271,7 @@ describe('[08. Gas Estimation Test]', () => {
 		expect(gas).to.not.equal(0);
 	});
 
-	it.only("7-3. Gov submitStakingParamsUpdateProposal gas estimation", async () => {
+	it("7-3. Gov submitStakingParamsUpdateProposal gas estimation", async () => {
 		
 		const initialDepositFCT = 5000;
 		const title = "Staking parameter change proposal";
@@ -291,7 +291,7 @@ describe('[08. Gas Estimation Test]', () => {
 		expect(gas).to.not.equal(0);
 	});
 
-	it.only("7-4, Gov submitGovParamsUpdateProposal gas estimation", async () => {
+	it("7-4, Gov submitGovParamsUpdateProposal gas estimation", async () => {
 		
 		const initialDepositFCT = 5000;
 		const title = "Gov parameter change proposal";

--- a/test/08.gas_estimate.test.ts
+++ b/test/08.gas_estimate.test.ts
@@ -276,8 +276,8 @@ describe('[08. Gas Estimation Test]', () => {
 		const initialDepositFCT = 5000;
 		const title = "Staking parameter change proposal";
 		const summary = "This is a Staking parameter change proposal";
-		const params = await firma.Staking.getParams();
-		params.max_validators = 100;
+		const params = await firma.Staking.getParamsAsStakingParams();
+		params.maxValidators = 100;
 		const metadata = "";
 
 		const gas = await firma.Gov.getGasEstimationSubmitStakingParamsUpdateProposal(

--- a/test/08.gas_estimate.test.ts
+++ b/test/08.gas_estimate.test.ts
@@ -271,7 +271,7 @@ describe('[08. Gas Estimation Test]', () => {
 		expect(gas).to.not.equal(0);
 	});
 
-	it("7-3. Gov submitStakingParamsUpdateProposal gas estimation", async () => {
+	it.only("7-3. Gov submitStakingParamsUpdateProposal gas estimation", async () => {
 		
 		const initialDepositFCT = 5000;
 		const title = "Staking parameter change proposal";
@@ -291,13 +291,13 @@ describe('[08. Gas Estimation Test]', () => {
 		expect(gas).to.not.equal(0);
 	});
 
-	it("7-4, Gov submitGovParamsUpdateProposal gas estimation", async () => {
+	it.only("7-4, Gov submitGovParamsUpdateProposal gas estimation", async () => {
 		
 		const initialDepositFCT = 5000;
 		const title = "Gov parameter change proposal";
 		const summary = "This is a Gov parameter change proposal";
-		const params = await firma.Gov.getParam();
-		params.burn_proposal_deposit_prevote = true;
+		const params = await firma.Gov.getParamAsGovParams();
+		params.burnProposalDepositPrevote = true;
 		const metadata = "";
 
 		const gas = await firma.Gov.getGasEstimationSubmitGovParamsUpdateProposal(aliceWallet, title, summary, initialDepositFCT, params, metadata);

--- a/test/13.staking_query.test.ts
+++ b/test/13.staking_query.test.ts
@@ -56,13 +56,13 @@ describe('[13. Staking Query Test]', () => {
 	});
 
 
-	it.only('6.get getParams', async () => {
+	it('6.get getParams', async () => {
 
 		const result = await firma.Staking.getParams();
 		expect(result.max_validators).to.not.equal(0);
 	});
 
-	it.only('6-1.get getParamsAsStakingParams', async () => {
+	it('6-1.get getParamsAsStakingParams', async () => {
 		
 		const result = await firma.Staking.getParamsAsStakingParams();
 		expect(result.maxValidators).to.not.equal(0);

--- a/test/13.staking_query.test.ts
+++ b/test/13.staking_query.test.ts
@@ -56,13 +56,14 @@ describe('[13. Staking Query Test]', () => {
 	});
 
 
-	it('6.get getParams', async () => {
+	it.only('6.get getParams', async () => {
 
 		const result = await firma.Staking.getParams();
 		expect(result.max_validators).to.not.equal(0);
 	});
 
-	it('6-1.get getParamsAsStakingParams', async () => {
+	it.only('6-1.get getParamsAsStakingParams', async () => {
+		
 		const result = await firma.Staking.getParamsAsStakingParams();
 		expect(result.maxValidators).to.not.equal(0);
 	});

--- a/test/13.staking_query.test.ts
+++ b/test/13.staking_query.test.ts
@@ -62,6 +62,11 @@ describe('[13. Staking Query Test]', () => {
 		expect(result.max_validators).to.not.equal(0);
 	});
 
+	it('6-1.get getParamsAsStakingParams', async () => {
+		const result = await firma.Staking.getParamsAsStakingParams();
+		expect(result.maxValidators).to.not.equal(0);
+	});
+
 	// user side
 	it('7.get userside getTotalDelegationInfo', async () => {
 

--- a/test/16.gov_tx.test.ts
+++ b/test/16.gov_tx.test.ts
@@ -70,9 +70,9 @@ describe('[16. Gov Tx Test]', () => {
 		const summary = "This is a Staking Parameter change proposal";
 		const initialDepositFCT = 2500;
 		
-		const params = await firma.Staking.getParams();
-		params.max_validators = 100;
-		params.historical_entries = 10000;
+		const params = await firma.Staking.getParamsAsStakingParams();
+		params.maxValidators = 100;
+		params.historicalEntries = 10000;
 		const metadata = "";
 		
 		const result = await firma.Gov.submitStakingParamsUpdateProposal(aliceWallet, title, summary, initialDepositFCT, params, metadata);
@@ -84,8 +84,8 @@ describe('[16. Gov Tx Test]', () => {
 		const title = "Staking Parameter Change proposal";
 		const summary = "This is a Staking Parameter change proposal";
 		const initialDepositFCT = 2500;
-		const params = await firma.Gov.getParam();
-		params.burn_proposal_deposit_prevote = true;
+		const params = await firma.Gov.getParamAsGovParams();
+		params.burnProposalDepositPrevote = true;
 		const metadata = "";
 
 		const result = await firma.Gov.submitGovParamsUpdateProposal(aliceWallet, title, summary, initialDepositFCT, params, metadata);

--- a/test/16.gov_tx.test.ts
+++ b/test/16.gov_tx.test.ts
@@ -64,7 +64,7 @@ describe('[16. Gov Tx Test]', () => {
 		expect(result.code).to.equal(0);
 	});
 
-	it.only('SubmitStakingParamsUpdateProposal Test', async () => {
+	it('SubmitStakingParamsUpdateProposal Test', async () => {
 
 		const title = "Staking Parameter Change proposal";
 		const summary = "This is a Staking Parameter change proposal";
@@ -79,7 +79,7 @@ describe('[16. Gov Tx Test]', () => {
 		expect(result.code).to.equal(0);
 	});
 
-	it.only('SubmitGovParamsUpdateProposal Test', async () => {
+	it('SubmitGovParamsUpdateProposal Test', async () => {
 		
 		const title = "Gov Parameter Change proposal";
 		const summary = "This is a Gov Parameter change proposal";

--- a/test/16.gov_tx.test.ts
+++ b/test/16.gov_tx.test.ts
@@ -64,7 +64,7 @@ describe('[16. Gov Tx Test]', () => {
 		expect(result.code).to.equal(0);
 	});
 
-	it('SubmitStakingParamsUpdateProposal Test', async () => {
+	it.only('SubmitStakingParamsUpdateProposal Test', async () => {
 
 		const title = "Staking Parameter Change proposal";
 		const summary = "This is a Staking Parameter change proposal";
@@ -79,10 +79,10 @@ describe('[16. Gov Tx Test]', () => {
 		expect(result.code).to.equal(0);
 	});
 
-	it('SubmitGovParamsUpdateProposal Test', async () => {
+	it.only('SubmitGovParamsUpdateProposal Test', async () => {
 		
-		const title = "Staking Parameter Change proposal";
-		const summary = "This is a Staking Parameter change proposal";
+		const title = "Gov Parameter Change proposal";
+		const summary = "This is a Gov Parameter change proposal";
 		const initialDepositFCT = 2500;
 		const params = await firma.Gov.getParamAsGovParams();
 		params.burnProposalDepositPrevote = true;

--- a/test/17.gov_query.test.ts
+++ b/test/17.gov_query.test.ts
@@ -53,14 +53,14 @@ describe('[17. Gov Query Test]', () => {
 	});
 
 	// integrated function with params/voting, params/deposit, params/tallying
-	it.only('get params', async () => {
+	it('get params', async () => {
 
 		const param = await firma.Gov.getParam();
 		expect(param).to.be.an('object');
 	});
 
 	// integrated function with params/voting, params/deposit, params/tallying - GovParams
-	it.only('get params as GovParams', async () => {
+	it('get params as GovParams', async () => {
 		
 		const param = await firma.Gov.getParamAsGovParams();
 		expect(param).to.be.an('object');

--- a/test/17.gov_query.test.ts
+++ b/test/17.gov_query.test.ts
@@ -54,8 +54,13 @@ describe('[17. Gov Query Test]', () => {
 
 	// integrated function with params/voting, params/deposit, params/tallying
 	it('get params', async () => {
-
 		const param = await firma.Gov.getParam();
+		expect(param).to.be.an('object');
+	});
+
+	// integrated function with params/voting, params/deposit, params/tallying - GovParams
+	it('get params as GovParams', async () => {
+		const param = await firma.Gov.getParamAsGovParams();
 		expect(param).to.be.an('object');
 	});
 

--- a/test/17.gov_query.test.ts
+++ b/test/17.gov_query.test.ts
@@ -53,13 +53,15 @@ describe('[17. Gov Query Test]', () => {
 	});
 
 	// integrated function with params/voting, params/deposit, params/tallying
-	it('get params', async () => {
+	it.only('get params', async () => {
+
 		const param = await firma.Gov.getParam();
 		expect(param).to.be.an('object');
 	});
 
 	// integrated function with params/voting, params/deposit, params/tallying - GovParams
-	it('get params as GovParams', async () => {
+	it.only('get params as GovParams', async () => {
+		
 		const param = await firma.Gov.getParamAsGovParams();
 		expect(param).to.be.an('object');
 	});


### PR DESCRIPTION
- cleaner approach to address parameter validation for governance
- after applying these changes, should fix ecosystem services to use `getParamsAs***Params()` function to get default structure. or it will revert.