### PR TITLE
fix validation logic and add test cases to cover firmautil/gov param

### DIFF
--- a/sdk/FirmaGovService.ts
+++ b/sdk/FirmaGovService.ts
@@ -112,17 +112,19 @@ export class FirmaGovService {
                 authority: FirmaGovService.GOV_AUTHORITY,
                 params: params
             });
-            const paramsEncoded = StakingMsgUpdateParams.encode(requestedParams).finish();
-            const fromPartialEncoded = StakingMsgUpdateParams.encode(fromPartialParams).finish();
 
-            if (Buffer.from(paramsEncoded).toString('hex') !== Buffer.from(fromPartialEncoded).toString('hex')) {
+            if (!equal(requestedParams.params, fromPartialParams.params)) {
                 throw new Error("All staking parameters must be provided. Use Staking.getParamsAsStakingParams() to get current values and override only the parameters you want to change.");
             }
 
             const message = {
                 typeUrl: "/cosmos.staking.v1beta1.MsgUpdateParams",
-                value: paramsEncoded
+                value: StakingMsgUpdateParams.encode(StakingMsgUpdateParams.fromPartial({
+                    authority: FirmaGovService.GOV_AUTHORITY,
+                    params: params
+                })).finish()
             };
+
             const txRaw = await this.getSignedTxSubmitStakingParamsUpdateProposal(wallet, title, summary, initialDepositFCT, [message], metadata, txMisc);
             return await FirmaUtil.estimateGas(txRaw);
         } catch (error) {
@@ -148,16 +150,17 @@ export class FirmaGovService {
                 authority: FirmaGovService.GOV_AUTHORITY,
                 params: params
             });
-            const paramsEncoded = GovMsgUpdateParmas.encode(requestedParams).finish();
-            const fromPartialEncoded = GovMsgUpdateParmas.encode(fromPartialParams).finish();
 
-            if (Buffer.from(paramsEncoded).toString('hex') !== Buffer.from(fromPartialEncoded).toString('hex')) {
+            if (!equal(requestedParams.params, fromPartialParams.params)) {
                 throw new Error("All governance parameters must be provided. Use getParamAsGovParams() to get current values and override only the parameters you want to change.");
             }
             
             const message = {
                 typeUrl: "/cosmos.gov.v1.MsgUpdateParams",
-                value: paramsEncoded
+                value: GovMsgUpdateParmas.encode(GovMsgUpdateParmas.fromPartial({
+                    authority: FirmaGovService.GOV_AUTHORITY,
+                    params: params
+                })).finish()
             }
 
             const txRaw = await this.getSignedTxSubmitGovParamsUpdateProposal(wallet, title, summary, initialDepositFCT, [message], metadata, txMisc);
@@ -455,15 +458,17 @@ export class FirmaGovService {
                 authority: FirmaGovService.GOV_AUTHORITY,
                 params: params
             });
-            const paramsEncoded = StakingMsgUpdateParams.encode(requestedParams).finish();
-
+    
             if (!equal(requestedParams.params, fromPartialParams.params)) {
                 throw new Error("All staking parameters must be provided. Use Staking.getParamsAsStakingParams() to get current values and override only the parameters you want to change.");
             }
 
             const message = {
                 typeUrl: "/cosmos.staking.v1beta1.MsgUpdateParams",
-                value: paramsEncoded
+                value: StakingMsgUpdateParams.encode(StakingMsgUpdateParams.fromPartial({
+                    authority: FirmaGovService.GOV_AUTHORITY,
+                    params: params
+                })).finish()
             };
 
             const txRaw = await this.getSignedTxSubmitStakingParamsUpdateProposal(wallet, title, summary, initialDepositFCT, [message], metadata, txMisc);
@@ -493,7 +498,7 @@ export class FirmaGovService {
                 authority: FirmaGovService.GOV_AUTHORITY,
                 params: params
             });
-            
+
             if (!equal(requestedParams.params, fromPartialParams.params)) {
                 throw new Error("All governance parameters must be provided. Use getParamAsGovParams() to get current values and override only the parameters you want to change.");
             }

--- a/sdk/FirmaGovService.ts
+++ b/sdk/FirmaGovService.ts
@@ -7,7 +7,6 @@ import {
     CurrentVoteInfo,
     GovParamType,
 } from "./firmachain/gov";
-import { StakingParamType } from "./firmachain/staking";
 import { DeliverTxResponse } from "./firmachain/common/stargateclient";
 import { Any } from "./firmachain/google/protobuf/any";
 import { FirmaWalletService } from "./FirmaWalletService";
@@ -19,6 +18,7 @@ import { Plan } from "cosmjs-types/cosmos/upgrade/v1beta1/upgrade";
 import { Coin } from "cosmjs-types/cosmos/base/v1beta1/coin";
 import { TextProposal } from "cosmjs-types/cosmos/gov/v1beta1/gov";
 import { MsgUpdateParams as StakingMsgUpdateParams } from "cosmjs-types/cosmos/staking/v1beta1/tx";
+import equal from 'fast-deep-equal';
 
 import {
     MsgCancelProposal,
@@ -456,9 +456,8 @@ export class FirmaGovService {
                 params: params
             });
             const paramsEncoded = StakingMsgUpdateParams.encode(requestedParams).finish();
-            const fromPartialEncoded = StakingMsgUpdateParams.encode(fromPartialParams).finish();
 
-            if (Buffer.from(paramsEncoded).toString('hex') !== Buffer.from(fromPartialEncoded).toString('hex')) {
+            if (!equal(requestedParams.params, fromPartialParams.params)) {
                 throw new Error("All staking parameters must be provided. Use Staking.getParamsAsStakingParams() to get current values and override only the parameters you want to change.");
             }
 
@@ -494,10 +493,8 @@ export class FirmaGovService {
                 authority: FirmaGovService.GOV_AUTHORITY,
                 params: params
             });
-            const paramsEncoded = GovMsgUpdateParmas.encode(requestedParams).finish();
-            const fromPartialEncoded = GovMsgUpdateParmas.encode(fromPartialParams).finish();
-
-            if (Buffer.from(paramsEncoded).toString('hex') !== Buffer.from(fromPartialEncoded).toString('hex')) {
+            
+            if (!equal(requestedParams.params, fromPartialParams.params)) {
                 throw new Error("All governance parameters must be provided. Use getParamAsGovParams() to get current values and override only the parameters you want to change.");
             }
 

--- a/sdk/FirmaUtil.ts
+++ b/sdk/FirmaUtil.ts
@@ -419,21 +419,20 @@ export class FirmaUtil {
      * @param durationStr - Duration string to parse (e.g., "336h0m0s", "21d")
      * @returns Duration object with seconds and nanos fields
      */
-    static parseDurationString(durationStr: string): { seconds: number; nanos: number } {
+    static parseDurationString(durationStr: string): { seconds: bigint; nanos: number } {
         if (!durationStr || durationStr.trim() === "") {
-            return { seconds: 0, nanos: 0 };
+            return { seconds: BigInt(0), nanos: 0 };
         }
-
+    
         const input = durationStr.trim();
         let totalSeconds = 0;
         let totalNanos = 0;
-
+    
         // Handle negative durations
         const isNegative = input.startsWith('-');
         const cleanInput = isNegative ? input.substring(1) : input;
-
+    
         // Regular expression to match duration components
-        // Matches patterns like: 1d, 2h, 3m, 4s, 5ms, 6µs, 7ns
         const regex = /(\d+(?:\.\d+)?)(d|h|m|s|ms|µs|us|ns)/g;
         let match;
         let hasMatches = false;
@@ -478,15 +477,13 @@ export class FirmaUtil {
         totalSeconds += extraSeconds;
         totalNanos = totalNanos % 1_000_000_000;
 
-        // Apply negative sign if needed
-        if (isNegative) {
-            totalSeconds = -totalSeconds;
-            totalNanos = -totalNanos;
-        }
-
+        // Apply negative sign
+        const finalSeconds = isNegative ? -totalSeconds : totalSeconds;
+        const finalNanos = isNegative ? -totalNanos : totalNanos;
+    
         return {
-            seconds: Math.floor(totalSeconds),
-            nanos: Math.floor(totalNanos)
+            seconds: BigInt(Math.floor(finalSeconds)),
+            nanos: Math.floor(finalNanos)
         };
     }
 

--- a/test/16.gov_tx.test.ts
+++ b/test/16.gov_tx.test.ts
@@ -188,4 +188,45 @@ describe('[16. Gov Tx Test]', () => {
 		result = await firma.Gov.vote(aliceWallet, proposalId, VotingOption.VOTE_OPTION_NO);
 		expect(result.code).to.equal(0);
 	});
+
+	it('SubmitGovParamsUpdateProposal Test - failure case (missing parameter)', async () => {
+
+		const title = "Gov Parameter Change fail proposal";
+		const summary = "This is a Gov Parameter change proposal";
+		const initialDeposit = 5000;
+
+		const params = await firma.Gov.getParamAsGovParams();
+		
+		// Modify only the fields you want to update.
+		// For example:
+		// params.burnVoteVeto = false;
+		// params.threshold = "0.600000000000000000";
+		
+		// This will fail, because not all required fields are included in the object.
+		// Only some fields are selected from the full params.
+		const proposalParams = {
+			burnVoteQuorum: false,
+			minDeposit: params.minDeposit,
+			quorum: params.quorum,
+			threshold: params.threshold,
+			vetoThreshold: params.vetoThreshold,
+			minInitialDepositRatio: params.minInitialDepositRatio,
+			proposalCancelRatio: params.proposalCancelRatio,
+			proposalCancelDest: params.proposalCancelDest,
+			expeditedThreshold: params.expeditedThreshold,
+			expeditedMinDeposit: params.expeditedMinDeposit,
+			burnProposalDepositPrevote: params.burnProposalDepositPrevote,
+			burnVoteVeto: params.burnVoteVeto,
+			minDepositRatio: params.minDepositRatio
+		};
+		const metadata = "";
+		
+		const errorMsg = "All governance parameters must be provided. Use getParamAsGovParams() to get current values and override only the parameters you want to change.";
+
+		try {
+			await firma.Gov.submitGovParamsUpdateProposal(aliceWallet, title, summary, initialDeposit, proposalParams, metadata);
+		} catch (error: any) {
+			expect(error.message).to.equal(errorMsg);
+		}
+	});
 });

--- a/test/16.gov_tx.test.ts
+++ b/test/16.gov_tx.test.ts
@@ -195,8 +195,6 @@ describe('[16. Gov Tx Test]', () => {
 		const summary = "This is a Gov Parameter change proposal";
 		const initialDeposit = 5000;
 
-		const params = await firma.Gov.getParamAsGovParams();
-		
 		// Modify only the fields you want to update.
 		// For example:
 		// params.burnVoteVeto = false;
@@ -204,20 +202,8 @@ describe('[16. Gov Tx Test]', () => {
 		
 		// This will fail, because not all required fields are included in the object.
 		// Only some fields are selected from the full params.
-		const proposalParams = {
-			burnVoteQuorum: false,
-			minDeposit: params.minDeposit,
-			quorum: params.quorum,
-			threshold: params.threshold,
-			vetoThreshold: params.vetoThreshold,
-			minInitialDepositRatio: params.minInitialDepositRatio,
-			proposalCancelRatio: params.proposalCancelRatio,
-			proposalCancelDest: params.proposalCancelDest,
-			expeditedThreshold: params.expeditedThreshold,
-			expeditedMinDeposit: params.expeditedMinDeposit,
-			burnProposalDepositPrevote: params.burnProposalDepositPrevote,
-			burnVoteVeto: params.burnVoteVeto,
-			minDepositRatio: params.minDepositRatio
+		const proposalParams: any = {
+			burnVoteQuorum: false
 		};
 		const metadata = "";
 		
@@ -225,6 +211,26 @@ describe('[16. Gov Tx Test]', () => {
 
 		try {
 			await firma.Gov.submitGovParamsUpdateProposal(aliceWallet, title, summary, initialDeposit, proposalParams, metadata);
+		} catch (error: any) {
+			expect(error.message).to.equal(errorMsg);
+		}
+	});
+
+	it('SubmitStakingParamsUpdateProposal Test - failure case (missing parameter)', async () => {
+
+		const title = "Staking Parameter Change fail proposal";
+		const summary = "This is a Staking Parameter change proposal";
+		const initialDeposit = 5000;
+
+		const proposalParams: any = {
+			maxValidators: 100
+		};
+		const metadata = "";
+		
+		const errorMsg = "All staking parameters must be provided. Use Staking.getParamsAsStakingParams() to get current values and override only the parameters you want to change.";
+
+		try {
+			await firma.Gov.submitStakingParamsUpdateProposal(aliceWallet, title, summary, initialDeposit, proposalParams, metadata);
 		} catch (error: any) {
 			expect(error.message).to.equal(errorMsg);
 		}

--- a/test/18.util.test.ts
+++ b/test/18.util.test.ts
@@ -230,4 +230,72 @@ describe('[18. util Test]', () => {
 		// hash from sha256 online
 		expect(hash).to.be.equal("b94d27b9934d3e08a52e52d7da7dabfac484efe37a5380ee9088f7ace2efcde9");
 	})
+
+	it('parseDurationString test', async () => {
+
+		const testString = "1800s";
+		const duration = FirmaUtil.parseDurationString(testString);
+
+		// Correct way to test object properties
+		expect(duration.seconds).to.be.equal(BigInt(1800));
+		expect(duration.nanos).to.be.equal(0);
+	})
+
+	it('createDurationFromString test', async () => {
+		
+		const testString = "1800s";
+		const duration = FirmaUtil.createDurationFromString(testString);
+
+		expect(duration.seconds).to.be.equal(BigInt(1800));
+		expect(duration.nanos).to.be.equal(0);
+	})
+
+	it('normalizeDecimalString test - success case', async () => {
+
+		const result = FirmaUtil.normalizeDecimalString("0.000000000000000000");
+		expect(result).to.equal("");
+	})
+
+	it('normalizeDecimalString test - failure case', async () => {
+
+		const result = FirmaUtil.normalizeDecimalString("0.000000000000000000");
+		expect(result).to.not.equal("0.000000000000000000");
+	})
+
+	it('processCommissionRate test - success case', async () => {
+
+		let result = FirmaUtil.processCommissionRate("0.000000000000000000");
+		expect(result).to.equal("");
+
+		result = FirmaUtil.processCommissionRate("0.1");
+		expect(result).to.equal("0.1");
+
+		result = FirmaUtil.processCommissionRate("1");
+		expect(result).to.equal("1");
+
+		result = FirmaUtil.processCommissionRate(" 0.75 ");
+		expect(result).to.equal("0.75");
+
+		result = FirmaUtil.processCommissionRate("");
+		expect(result).to.equal("");
+	})
+
+	it('processCommissionRate - failure cases', async () => {
+
+		// Invalid commission rate: 1.01. Must be <= 1
+		let testString = "1.01";
+		try {
+			FirmaUtil.processCommissionRate(testString);
+		} catch (error: any) {
+			expect(error.message).to.equal("Invalid commission rate format: 1.01");
+		}
+
+		// Invalid commission rate: -0.1. Must be >= 0
+		testString = "-0.1";
+		try {
+			FirmaUtil.processCommissionRate(testString)
+		} catch (error: any) {
+			expect(error.message).to.equal("Invalid commission rate format: -0.1");
+		}
+	})
 });


### PR DESCRIPTION
- use `equal()` to validate user request and actual tx
- add test cases to cover gov proposals
- add test cases to cover firmautil