### PR TITLE
fix: edit regex to not filter negative number, but filter .00 numbers

### DIFF
--- a/sdk/FirmaUtil.ts
+++ b/sdk/FirmaUtil.ts
@@ -522,7 +522,7 @@ export class FirmaUtil {
             throw new Error(`Invalid commission rate format: ${commissionRate}`);
         }
         
-        if (!/^(\d+\.?\d*|\.\d+)$/.test(trimmed)) {
+        if (!/^-?\d+\.?\d*$/.test(trimmed)) {
             throw new Error(`Invalid commission rate format: ${commissionRate}`);
         }
         

--- a/test/18.util.test.ts
+++ b/test/18.util.test.ts
@@ -273,7 +273,7 @@ describe('[18. util Test]', () => {
 
 	it('processCommissionRateAsDecimal test - failure cases', async () => {
 
-		expect(() => FirmaUtil.processCommissionRateAsDecimal(".")).to.throw("Invalid commission rate format");
+		expect(() => FirmaUtil.processCommissionRateAsDecimal(".")).to.throw("Invalid commission rate format: .");
 		
 		expect(() => FirmaUtil.processCommissionRateAsDecimal("")).to.throw("Invalid commission rate format: ");
 		
@@ -283,9 +283,9 @@ describe('[18. util Test]', () => {
 		
 		expect(() => FirmaUtil.processCommissionRateAsDecimal("0.1abc")).to.throw("Invalid commission rate format: 0.1abc");
 		
-		expect(() => FirmaUtil.processCommissionRateAsDecimal("0.1.2")).to.throw("Invalid commission rate format");
+		expect(() => FirmaUtil.processCommissionRateAsDecimal("0.1.2")).to.throw("Invalid commission rate format: 0.1.2");
 		
-		expect(() => FirmaUtil.processCommissionRateAsDecimal("--0.5")).to.throw("Invalid commission rate format");
+		expect(() => FirmaUtil.processCommissionRateAsDecimal("--0.5")).to.throw("Invalid commission rate format: --0.5");
 		
 		expect(() => FirmaUtil.processCommissionRateAsDecimal("1.01")).to.throw("Invalid commission rate range. Must be between 0 and 1 inclusive.");
 		
@@ -297,14 +297,14 @@ describe('[18. util Test]', () => {
 
 		expect(() => FirmaUtil.processCommissionRateAsDecimal("-1")).to.throw("Invalid commission rate range. Must be between 0 and 1 inclusive.");
 
-		expect(() => FirmaUtil.processCommissionRateAsDecimal("-0.01")).to.throw("Invalid commission rate format: -0.01");
+		expect(() => FirmaUtil.processCommissionRateAsDecimal("-0.01")).to.throw("Invalid commission rate range. Must be between 0 and 1 inclusive.");
 
-		expect(() => FirmaUtil.processCommissionRateAsDecimal("-0.000000000000000001")).to.throw("Invalid commission rate format");
+		expect(() => FirmaUtil.processCommissionRateAsDecimal("-0.000000000000000001")).to.throw("Invalid commission rate range. Must be between 0 and 1 inclusive.");
 
 		expect(() => FirmaUtil.processCommissionRateAsDecimal("1.00000000000000000001")).to.throw("Invalid commission rate range. Must be between 0 and 1 inclusive.");
 
-		expect(() => FirmaUtil.processCommissionRateAsDecimal("0.5%")).to.throw("Invalid commission rate format");
+		expect(() => FirmaUtil.processCommissionRateAsDecimal("0.5%")).to.throw("Invalid commission rate format: 0.5%");
 		
-		expect(() => FirmaUtil.processCommissionRateAsDecimal(" 0.5 extra")).to.throw("Invalid commission rate format");
+		expect(() => FirmaUtil.processCommissionRateAsDecimal(" 0.5 extra")).to.throw("Invalid commission rate format:  0.5 extra");
 	})
 });

--- a/test/18.util.test.ts
+++ b/test/18.util.test.ts
@@ -293,9 +293,9 @@ describe('[18. util Test]', () => {
 		
 		expect(() => FirmaUtil.processCommissionRateAsDecimal("1.1")).to.throw("Invalid commission rate range. Must be between 0 and 1 inclusive.");
 		
-		expect(() => FirmaUtil.processCommissionRateAsDecimal("-0.1")).to.throw("Invalid commission rate format");
+		expect(() => FirmaUtil.processCommissionRateAsDecimal("-0.1")).to.throw("Invalid commission rate range. Must be between 0 and 1 inclusive.");
 
-		expect(() => FirmaUtil.processCommissionRateAsDecimal("-1")).to.throw("Invalid commission rate format");
+		expect(() => FirmaUtil.processCommissionRateAsDecimal("-1")).to.throw("Invalid commission rate range. Must be between 0 and 1 inclusive.");
 
 		expect(() => FirmaUtil.processCommissionRateAsDecimal("-0.01")).to.throw("Invalid commission rate format: -0.01");
 


### PR DESCRIPTION
## Ovierview

- don't filter negative number using regex, filter using bignumber comparison
- filter some point-starting cases like `.123` or `-.123`

## process unit tests

**Unit tests**

<img width="829" height="108" alt="image" src="https://github.com/user-attachments/assets/9ec0798b-59d9-4e84-8115-05037dca7be5" />

**Transaction result**

<img width="746" height="538" alt="image" src="https://github.com/user-attachments/assets/c9a314da-a562-47fa-ab10-887762fd9355" />
