### PR TITLE
fix: change ledger sign param auth to acc

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@firmachain/firma-js",
-  "version": "0.3.3",
+  "version": "0.3.4",
   "description": "The Official FirmaChain Javascript SDK written in Typescript",
   "main": "dist/index.js",
   "typings": "dist/index.d.ts",

--- a/sdk/firmachain/common/LedgerSigningStargateClient.ts
+++ b/sdk/firmachain/common/LedgerSigningStargateClient.ts
@@ -72,7 +72,7 @@ export class LedgerSigningStargateClient extends StargateClient {
 
       const path = "/abci_query";
       const params = {
-        path: "/store/auth/key",
+        path: "/store/acc/key",
         data: hexAccAddress,
       };
 


### PR DESCRIPTION
## Overview

- fixed wrong path
- /store/auth/key -> /store/acc/key

## Tests

- The query test was conducted targeting the testnet that had been upgraded to v0.5.0.
  ```
  {"jsonrpc":"2.0","id":-1,"result":{"response":{"code":0,"log":"","info":"","index":"0","key":"{key}","value":"{value}","proofOps":null,"height":"3786008","codespace":""}}}
  ```

- query
  ```
  curl -G 'https://lcd-testnet.firmachain.dev:26657/abci_query' \
    --data-urlencode 'path="/store/acc/key"' \
    --data-urlencode 'data=0x01{address to hex}'
  ```