### PR TITLE
chore: bump version to 0.4.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@firmachain/firma-js",
-  "version": "0.4.0-beta2",
+  "version": "0.4.0",
   "description": "The Official FirmaChain Javascript SDK written in Typescript",
   "main": "dist/index.js",
   "typings": "dist/index.d.ts",


### PR DESCRIPTION
## Summary

Promote `v0.4.0-beta2` to `v0.4.0` after testnet verification on Station.

Changes since `v0.3.8` (full scope already merged via #23):
- Ledger hardware wallet support with SIGN_MODE_TEXTUAL
- Single-prompt Ledger gas estimation (dummy-signed simulate)
- `FirmaStaking.getRedelegationListFromValidator` query
- TestNet/MainNet endpoint URL migration
- `longToNumber` overflow guard for uint64 decoding
- Privacy-aware Ledger debug logging

## Post-merge

- [ ] Tag `v0.4.0` and push
- [ ] `npm publish` (default `latest` tag)
- [ ] Create GitHub Release for `v0.4.0`