### PR TITLE
fix: bump axios to 1.16.0 (security) + bump version to 0.4.1

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@firmachain/firma-js",
-  "version": "0.3.7",
+  "version": "0.4.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@firmachain/firma-js",
-      "version": "0.3.7",
+      "version": "0.4.0",
       "license": "MIT License",
       "dependencies": {
         "@cosmjs/amino": "0.34.0",
@@ -19,7 +19,7 @@
         "@tharsis/address-converter": "0.1.8",
         "@types/pako": "2.0.0",
         "@zondax/ledger-cosmos-js": "^4.0.1",
-        "axios": "1.15.1",
+        "axios": "1.16.0",
         "bignumber.js": "^9.3.0",
         "cosmjs-types": "0.9.0",
         "crypto-js": "4.2.0",
@@ -711,12 +711,12 @@
       }
     },
     "node_modules/axios": {
-      "version": "1.15.1",
-      "resolved": "https://registry.npmjs.org/axios/-/axios-1.15.1.tgz",
-      "integrity": "sha512-WOG+Jj8ZOvR0a3rAn+Tuf1UQJRxw5venr6DgdbJzngJE3qG7X0kL83CZGpdHMxEm+ZK3seAbvFsw4FfOfP9vxg==",
+      "version": "1.16.0",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-1.16.0.tgz",
+      "integrity": "sha512-6hp5CwvTPlN2A31g5dxnwAX0orzM7pmCRDLnZSX772mv8WDqICwFjowHuPs04Mc8deIld1+ejhtaMn5vp6b+1w==",
       "license": "MIT",
       "dependencies": {
-        "follow-redirects": "^1.15.11",
+        "follow-redirects": "^1.16.0",
         "form-data": "^4.0.5",
         "proxy-from-env": "^2.1.0"
       }
@@ -4284,11 +4284,11 @@
       }
     },
     "axios": {
-      "version": "1.15.1",
-      "resolved": "https://registry.npmjs.org/axios/-/axios-1.15.1.tgz",
-      "integrity": "sha512-WOG+Jj8ZOvR0a3rAn+Tuf1UQJRxw5venr6DgdbJzngJE3qG7X0kL83CZGpdHMxEm+ZK3seAbvFsw4FfOfP9vxg==",
+      "version": "1.16.0",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-1.16.0.tgz",
+      "integrity": "sha512-6hp5CwvTPlN2A31g5dxnwAX0orzM7pmCRDLnZSX772mv8WDqICwFjowHuPs04Mc8deIld1+ejhtaMn5vp6b+1w==",
       "requires": {
-        "follow-redirects": "^1.15.11",
+        "follow-redirects": "^1.16.0",
         "form-data": "^4.0.5",
         "proxy-from-env": "^2.1.0"
       },

--- a/package.json
+++ b/package.json
@@ -44,7 +44,7 @@
     "@tharsis/address-converter": "0.1.8",
     "@types/pako": "2.0.0",
     "@zondax/ledger-cosmos-js": "^4.0.1",
-    "axios": "1.15.1",
+    "axios": "1.16.0",
     "bignumber.js": "^9.3.0",
     "cosmjs-types": "0.9.0",
     "crypto-js": "4.2.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@firmachain/firma-js",
-  "version": "0.4.0",
+  "version": "0.4.1",
   "description": "The Official FirmaChain Javascript SDK written in Typescript",
   "main": "dist/index.js",
   "typings": "dist/index.d.ts",

--- a/yarn.lock
+++ b/yarn.lock
@@ -469,12 +469,12 @@ available-typed-arrays@^1.0.7:
   dependencies:
     possible-typed-array-names "^1.0.0"
 
-axios@1.15.1:
-  version "1.15.1"
-  resolved "https://registry.npmjs.org/axios/-/axios-1.15.1.tgz"
-  integrity sha512-WOG+Jj8ZOvR0a3rAn+Tuf1UQJRxw5venr6DgdbJzngJE3qG7X0kL83CZGpdHMxEm+ZK3seAbvFsw4FfOfP9vxg==
+axios@1.16.0:
+  version "1.16.0"
+  resolved "https://registry.npmjs.org/axios/-/axios-1.16.0.tgz"
+  integrity sha512-6hp5CwvTPlN2A31g5dxnwAX0orzM7pmCRDLnZSX772mv8WDqICwFjowHuPs04Mc8deIld1+ejhtaMn5vp6b+1w==
   dependencies:
-    follow-redirects "^1.15.11"
+    follow-redirects "^1.16.0"
     form-data "^4.0.5"
     proxy-from-env "^2.1.0"
 
@@ -973,7 +973,7 @@ flat@^5.0.2:
   resolved "https://registry.npmjs.org/flat/-/flat-5.0.2.tgz"
   integrity sha512-b6suED+5/3rTpUBdG1gupIl8MPFCAMA0QXwmljLhvCUKcUvdE4gWky9zpuGCcXHOsz4J9wPGNWq6OKpmIzz3hQ==
 
-follow-redirects@^1.15.11:
+follow-redirects@^1.16.0:
   version "1.16.0"
   resolved "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.16.0.tgz"
   integrity sha512-y5rN/uOsadFT/JfYwhxRS5R7Qce+g3zG97+JrtFZlC9klX/W5hD7iiLzScI4nZqUS7DNUdhPgw4xI8W2LuXlUw==


### PR DESCRIPTION
## Summary

Patches two publicly disclosed axios advisories that affect 0.4.0 consumers:

- **GHSA-q8qp-cvcw-x6jj**
  - Prototype pollution in HTTP adapter → credential injection / request hijacking (CVSS 7.4, **high**)
- **GHSA-3w6x-2g7m-8v23**
  - Prototype pollution in `parseReviver` → invisible JSON response tampering (CVSS 6.5, moderate)

Affected range: `axios >=1.0.0 <1.15.2`. Fixed by bumping to `1.16.0` (semver-minor, no breaking changes).

## Why this matters for firma-js

The SDK uses axios for every RPC/REST call to FirmaChain and signs transactions based on the parsed responses. A tampered response could mislead the signing flow — high impact for users on 0.4.0.

## Verification

- `npm audit --omit=dev` → `found 0 vulnerabilities` (was 1 high)
- `npm run build` passes
- No code changes (version bump only)

## Post-merge

- [ ] Tag `v0.4.1` and push
- [ ] `npm publish` (default `latest` tag)
- [ ] Create GitHub Release for `v0.4.1`

## Related

Tracks longer-term migration from axios → ky in a separate issue (Node 22+ requirement → 0.5.0 territory).